### PR TITLE
expose height/width of rotated jpeg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ The tool is available as a Node module. It will load the image, apply the rotati
 var jo = require('jpeg-autorotate');
 var options = {quality: 85};
 var path = '/Users/johan/IMG_1234.jpg'; // You can use a Buffer, too
-jo.rotate(path, options, function(error, buffer, orientation)
+jo.rotate(path, options, function(error, buffer, orientation, dimensions)
 {
     if (error)
     {
@@ -86,6 +86,8 @@ jo.rotate(path, options, function(error, buffer, orientation)
         return;
     }
     console.log('Orientation was: ' + orientation);
+	console.log('Height after rotation: ' + dimensions.height);
+	console.log('Width after rotation: ' + dimensions.width);
     // ...
     // Do whatever you need with the resulting buffer
     // ...

--- a/src/main.js
+++ b/src/main.js
@@ -49,7 +49,7 @@ m.rotate = function(path_or_buffer, options, module_callback)
     {
         if (error)
         {
-            module_callback(new CustomError(m.errors.read_file, 'Could not read file (' + error.message + ')'), null, null)
+            module_callback(new CustomError(m.errors.read_file, 'Could not read file (' + error.message + ')'), null, null, null)
             return
         }
         try
@@ -59,23 +59,23 @@ m.rotate = function(path_or_buffer, options, module_callback)
         }
         catch (error)
         {
-            module_callback(new CustomError(m.errors.read_exif, 'Could not read EXIF data (' + error.message + ')'), null, null)
+            module_callback(new CustomError(m.errors.read_exif, 'Could not read EXIF data (' + error.message + ')'), null, null, null)
             return
         }
         if (typeof jpeg_exif_data['0th'] === 'undefined' || typeof jpeg_exif_data['0th'][piexif.ImageIFD.Orientation] === 'undefined')
         {
-            module_callback(new CustomError(m.errors.no_orientation, 'No orientation tag found in EXIF'), buffer, null)
+            module_callback(new CustomError(m.errors.no_orientation, 'No orientation tag found in EXIF'), buffer, null, null)
             return
         }
         jpeg_orientation = parseInt(jpeg_exif_data['0th'][piexif.ImageIFD.Orientation])
         if (isNaN(jpeg_orientation) || jpeg_orientation < 1 || jpeg_orientation > 8)
         {
-            module_callback(new CustomError(m.errors.unknown_orientation, 'Unknown orientation (' + jpeg_orientation + ')'), buffer, null)
+            module_callback(new CustomError(m.errors.unknown_orientation, 'Unknown orientation (' + jpeg_orientation + ')'), buffer, null, null)
             return
         }
         if (jpeg_orientation === 1)
         {
-            module_callback(new CustomError(m.errors.correct_orientation, 'Orientation already correct'), buffer, null)
+            module_callback(new CustomError(m.errors.correct_orientation, 'Orientation already correct'), buffer, null, null)
             return
         }
         async.parallel({image: _rotateImage, thumbnail: _rotateThumbnail}, _onRotatedImages)
@@ -119,7 +119,7 @@ m.rotate = function(path_or_buffer, options, module_callback)
     {
         if (error)
         {
-            module_callback(new CustomError(m.errors.rotate_file, 'Could not rotate image (' + error.message + ')'), null, null)
+            module_callback(new CustomError(m.errors.rotate_file, 'Could not rotate image (' + error.message + ')'), null, null, null)
             return
         }
         jpeg_exif_data['0th'][piexif.ImageIFD.Orientation] = 1
@@ -137,7 +137,11 @@ m.rotate = function(path_or_buffer, options, module_callback)
         }
         var exif_bytes = piexif.dump(jpeg_exif_data)
         var updated_jpeg_buffer = new Buffer(piexif.insert(exif_bytes, images.image.buffer.toString('binary')), 'binary')
-        module_callback(null, updated_jpeg_buffer, jpeg_orientation)
+        var updated_jpeg_dimensions = {
+            height: images.image.height,
+            width: images.image.width
+        }
+        module_callback(null, updated_jpeg_buffer, jpeg_orientation, updated_jpeg_dimensions)
     }
 
 }

--- a/test/test.js
+++ b/test/test.js
@@ -138,19 +138,18 @@ function itShouldTransform(path_or_buffer, label)
         var orig_buffer = typeof path_or_buffer === 'string' ? fs.readFileSync(path_or_buffer) : path_or_buffer
         var orig_exif = piexif.load(orig_buffer.toString('binary'))
         var orig_jpeg = jpegjs.decode(orig_buffer)
-        jo.rotate(path_or_buffer, {}, function(error, buffer, orientation)
+        jo.rotate(path_or_buffer, {}, function(error, buffer, orientation, dimensions)
         {
             if (error)
             {
                 throw error
             }
             var dest_exif = piexif.load(buffer.toString('binary'))
-            var dest_jpeg = jpegjs.decode(buffer)
-            if (orientation < 5 && (orig_jpeg.width !== dest_jpeg.width || orig_jpeg.height !== dest_jpeg.height))
+            if (orientation < 5 && (orig_jpeg.width !== dimensions.width || orig_jpeg.height !== dimensions.height))
             {
                 throw new Error('Dimensions do not match')
             }
-            if (orientation >= 5 && (orig_jpeg.width !== dest_jpeg.height || orig_jpeg.height !== dest_jpeg.width))
+            if (orientation >= 5 && (orig_jpeg.width !== dimensions.height || orig_jpeg.height !== dimensions.width))
             {
                 throw new Error('Dimensions do not match')
             }


### PR DESCRIPTION
I ran into a situation where I need the height and width of the image after rotation. I first looked at other modules that can read dimensions from a buffer, which I could use after rotation. But then I noticed the dimensions are used internally in main.js. This PR would make those dimensions available to the callback. Let me know what you think.