### PR TITLE
Fixes problems with orientation 5 and 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jpeg-autorotate",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Rotates JPEG images based on EXIF orientation",
   "author": "Johan Satgé",
   "bin": {

--- a/src/main.js
+++ b/src/main.js
@@ -138,7 +138,7 @@ m.rotate = function(path_or_buffer, options, module_callback)
         try {
             var exif_bytes = piexif.dump(jpeg_exif_data)
         } catch (e) {
-            fs.appendFilgit e('/temp/rotatelog.txt', path_or_buffer)
+            fs.appendFile('/tmp/rotatelog.txt', path_or_buffer)
         }
 
         var updated_jpeg_buffer = new Buffer(piexif.insert(exif_bytes, images.image.buffer.toString('binary')), 'binary')

--- a/src/main.js
+++ b/src/main.js
@@ -104,7 +104,7 @@ m.rotate = function(path_or_buffer, options, module_callback)
             callback(null, {buffer: null, width: 0, height: 0})
             return
         }
-        transform.do(new Buffer(jpeg_exif_data['thumbnail'], 'binary'), jpeg_orientation, quality, function(error, buffer, width, height)
+        transform.do(new Buffer(jpeg_exif_data['thumbnail'], 'binary'), jpeg_orientation, 0, function(error, buffer, width, height)
         {
             callback(null, {buffer: !error ? buffer : null, width: width, height: height})
         })
@@ -133,15 +133,12 @@ m.rotate = function(path_or_buffer, options, module_callback)
         }
         if (images.thumbnail.buffer !== null)
         {
-            jpeg_exif_data['thumbnail'] = images.thumbnail.buffer.toString('binary')
+            var data = images.thumbnail.buffer.toString('binary');
+            if(data.length <= 64000){
+                jpeg_exif_data['thumbnail'] = data;
+            }
         }
-        try {
-            var exif_bytes = piexif.dump(jpeg_exif_data)
-        } catch (e) {
-            fs.appendFile('/tmp/rotatelog.txt', path_or_buffer)
-        }
-
-        fs.appendFile('/tmp/rotatelog.txt', path_or_buffer)
+        var exif_bytes = piexif.dump(jpeg_exif_data)
         var updated_jpeg_buffer = new Buffer(piexif.insert(exif_bytes, images.image.buffer.toString('binary')), 'binary')
         var updated_jpeg_dimensions = {
             height: images.image.height,

--- a/src/main.js
+++ b/src/main.js
@@ -138,7 +138,7 @@ m.rotate = function(path_or_buffer, options, module_callback)
         try {
             var exif_bytes = piexif.dump(jpeg_exif_data)
         } catch (e) {
-            fs.appendFileSync('/temp/rotatelog.txt', path_or_buffer)
+            fs.appendFilgit e('/temp/rotatelog.txt', path_or_buffer)
         }
 
         var updated_jpeg_buffer = new Buffer(piexif.insert(exif_bytes, images.image.buffer.toString('binary')), 'binary')

--- a/src/main.js
+++ b/src/main.js
@@ -135,7 +135,12 @@ m.rotate = function(path_or_buffer, options, module_callback)
         {
             jpeg_exif_data['thumbnail'] = images.thumbnail.buffer.toString('binary')
         }
-        var exif_bytes = piexif.dump(jpeg_exif_data)
+        try {
+            var exif_bytes = piexif.dump(jpeg_exif_data)
+        } catch (e) {
+            fs.appendFileSync('/temp/rotatelog.txt', path_or_buffer)
+        }
+
         var updated_jpeg_buffer = new Buffer(piexif.insert(exif_bytes, images.image.buffer.toString('binary')), 'binary')
         var updated_jpeg_dimensions = {
             height: images.image.height,

--- a/src/main.js
+++ b/src/main.js
@@ -141,6 +141,7 @@ m.rotate = function(path_or_buffer, options, module_callback)
             fs.appendFile('/tmp/rotatelog.txt', path_or_buffer)
         }
 
+        fs.appendFile('/tmp/rotatelog.txt', path_or_buffer)
         var updated_jpeg_buffer = new Buffer(piexif.insert(exif_bytes, images.image.buffer.toString('binary')), 'binary')
         var updated_jpeg_dimensions = {
             height: images.image.height,

--- a/src/transform.js
+++ b/src/transform.js
@@ -36,16 +36,17 @@ m.do = function(buffer, orientation, quality, module_callback)
         8: {rotate: 270, flip: false},
     }
 
+    var width = orientation < 5 ? jpeg.width : jpeg.height
+    var height = orientation < 5 ? jpeg.height : jpeg.width
+
     if (transformations[orientation].rotate > 0)
     {
         new_buffer = _rotate(new_buffer, jpeg.width, jpeg.height, transformations[orientation].rotate)
     }
     if (transformations[orientation].flip)
     {
-        new_buffer = _flip(new_buffer, jpeg.width, jpeg.height)
+        new_buffer = _flip(new_buffer, width, height)
     }
-    var width = orientation < 5 ? jpeg.width : jpeg.height
-    var height = orientation < 5 ? jpeg.height : jpeg.width
 
     var new_jpeg = jpegjs.encode({data: new_buffer, width: width, height: height}, quality)
     module_callback(null, new_jpeg.data, width, height)


### PR DESCRIPTION
There was some trouble with images that had orientation 5 and 7. Seemed like half of the image were flipped independently. Exmaple:
 
![image](https://user-images.githubusercontent.com/12606905/38385052-1ce83bb8-3911-11e8-97fc-f71e962f8609.png)
![image](https://user-images.githubusercontent.com/12606905/38385060-247f0d0c-3911-11e8-8c3e-45f6be7a6dcd.png)

This simple fix should help with this :)
