### PR TITLE
fix for multiple files. Refactored out the vestigal index variable

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-const argv = require('yargs').argv
-const colors = require('colors')
-const fs = require('fs')
-const glob = require('glob')
-const jo = require('./main.js')
-const manifest = require('../package.json')
-const promisify = require('util').promisify
+const argv = require('yargs').argv;
+const colors = require('colors');
+const fs = require('fs');
+const glob = require('glob');
+const jo = require('./main.js');
+const manifest = require('../package.json');
+const promisify = require('util').promisify;
 
 if (argv.version) {
-  console.log(manifest.name + ' ' + manifest.version)
+  console.log(manifest.name + ' ' + manifest.version);
   process.exit(0)
 }
 
@@ -26,8 +26,8 @@ if (argv.help || typeof argv._ === 'undefined' || argv._.length === 0) {
     '--version           Output current version',
     '--help              Output help',
     '',
-  ]
-  console.log(help.join('\n'))
+  ];
+  console.log(help.join('\n'));
   process.exit(0)
 }
 
@@ -37,7 +37,7 @@ listFiles()
     process.exit(0)
   })
   .catch((error) => {
-    console.log(error.message)
+    console.log(error.message);
     process.exit(1)
   })
 
@@ -47,33 +47,36 @@ function listFiles() {
   })
 }
 
-function processFiles(files, index = 0) {
-  if (index + 1 > files.length) {
+function processFiles(files) {
+  if (files.length === 0) {
     return Promise.resolve()
   }
-  const filePath = files[index]
-  return jo
-    .rotate(filePath, {quality: argv.quality})
-    .then(({buffer, orientation, quality, dimensions}) => {
-      return promisify(fs.writeFile)(files[index], buffer).then(() => {
-        return {orientation, quality, dimensions}
-      })
-    })
-    .then(({orientation, quality, dimensions}) => {
-      const message =
-        'Processed (Orientation: ' +
-        orientation +
-        ') (Quality: ' +
-        quality +
-        '%) (Dimensions: ' +
-        dimensions.width +
-        'x' +
-        dimensions.height +
-        ')'
-      console.log(filePath + ': ' + colors.green(message))
-    })
-    .catch((error) => {
-      const isFatal = error.code !== jo.errors.correct_orientation
-      console.log(filePath + ': ' + (isFatal ? colors.red(error.message) : colors.yellow(error.message)))
-    })
+  const promiseArray = [];
+  files.forEach(filePath => {
+    promiseArray.push(jo
+        .rotate(filePath, {quality: argv.quality})
+        .then(({buffer, orientation, quality, dimensions}) => {
+          return promisify(fs.writeFile)(filePath, buffer).then(() => {
+            return {orientation, quality, dimensions}
+          })
+        })
+        .then(({orientation, quality, dimensions}) => {
+          const message =
+              'Processed (Orientation: ' +
+              orientation +
+              ') (Quality: ' +
+              quality +
+              '%) (Dimensions: ' +
+              dimensions.width +
+              'x' +
+              dimensions.height +
+              ')';
+          console.log(filePath + ': ' + colors.green(message))
+        })
+        .catch((error) => {
+          const isFatal = error.code !== jo.errors.correct_orientation;
+          console.log(filePath + ': ' + (isFatal ? colors.red(error.message) : colors.yellow(error.message)))
+        }));
+  });
+  return Promise.all(promiseArray).then (() => console.log('done processing files'));
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -76,7 +76,8 @@ function processFiles(files) {
       .catch((error) => {
         const isFatal = error.code !== jo.errors.correct_orientation
         console.log(filePath + ': ' + (isFatal ? colors.red(error.message) : colors.yellow(error.message)))
-      }))
+      })
+    )
   })
   return Promise.all(promiseArray).then(() => console.log('done processing files'))
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-const argv = require('yargs').argv;
-const colors = require('colors');
-const fs = require('fs');
-const glob = require('glob');
-const jo = require('./main.js');
-const manifest = require('../package.json');
-const promisify = require('util').promisify;
+const argv = require('yargs').argv
+const colors = require('colors')
+const fs = require('fs')
+const glob = require('glob')
+const jo = require('./main.js')
+const manifest = require('../package.json')
+const promisify = require('util').promisify
 
 if (argv.version) {
-  console.log(manifest.name + ' ' + manifest.version);
+  console.log(manifest.name + ' ' + manifest.version)
   process.exit(0)
 }
 
@@ -26,8 +26,8 @@ if (argv.help || typeof argv._ === 'undefined' || argv._.length === 0) {
     '--version           Output current version',
     '--help              Output help',
     '',
-  ];
-  console.log(help.join('\n'));
+  ]
+  console.log(help.join('\n'))
   process.exit(0)
 }
 
@@ -37,7 +37,7 @@ listFiles()
     process.exit(0)
   })
   .catch((error) => {
-    console.log(error.message);
+    console.log(error.message)
     process.exit(1)
   })
 
@@ -51,32 +51,32 @@ function processFiles(files) {
   if (files.length === 0) {
     return Promise.resolve()
   }
-  const promiseArray = [];
+  const promiseArray = []
   files.forEach(filePath => {
     promiseArray.push(jo
-        .rotate(filePath, {quality: argv.quality})
-        .then(({buffer, orientation, quality, dimensions}) => {
-          return promisify(fs.writeFile)(filePath, buffer).then(() => {
-            return {orientation, quality, dimensions}
-          })
+      .rotate(filePath, {quality: argv.quality})
+      .then(({buffer, orientation, quality, dimensions}) => {
+        return promisify(fs.writeFile)(filePath, buffer).then(() => {
+          return {orientation, quality, dimensions}
         })
-        .then(({orientation, quality, dimensions}) => {
-          const message =
-              'Processed (Orientation: ' +
-              orientation +
-              ') (Quality: ' +
-              quality +
-              '%) (Dimensions: ' +
-              dimensions.width +
-              'x' +
-              dimensions.height +
-              ')';
-          console.log(filePath + ': ' + colors.green(message))
-        })
-        .catch((error) => {
-          const isFatal = error.code !== jo.errors.correct_orientation;
-          console.log(filePath + ': ' + (isFatal ? colors.red(error.message) : colors.yellow(error.message)))
-        }));
-  });
-  return Promise.all(promiseArray).then (() => console.log('done processing files'));
+      })
+      .then(({orientation, quality, dimensions}) => {
+        const message =
+            'Processed (Orientation: ' +
+            orientation +
+            ') (Quality: ' +
+            quality +
+            '%) (Dimensions: ' +
+            dimensions.width +
+            'x' +
+            dimensions.height +
+            ')'
+        console.log(filePath + ': ' + colors.green(message))
+      })
+      .catch((error) => {
+        const isFatal = error.code !== jo.errors.correct_orientation
+        console.log(filePath + ': ' + (isFatal ? colors.red(error.message) : colors.yellow(error.message)))
+      }))
+  })
+  return Promise.all(promiseArray).then(() => console.log('done processing files'))
 }


### PR DESCRIPTION
There was an issue with processFiles where it was only processing the first file.  Looking at the git history it appears that this once relied on recursion but doesn't anymore.  This was causing it to exit too early.  I refactored it to do a forEach on the file array, losing the now-unnecessary index variable entirely.