### PR TITLE
New jpeg-js options

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "colors": "^1.4.0",
     "glob": "^7.1.6",
     "jpeg-js": "^0.4.2",
-    "piexifjs": "^1.0.6"
+    "piexifjs": "^1.0.6",
+    "yargs-parser": "^20.2.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -47,8 +48,7 @@
     "mocha": "^8.1.3",
     "pixelmatch": "^5.2.1",
     "pngjs": "^5.0.0",
-    "prettier": "^2.1.2",
-    "yargs": "^16.0.3"
+    "prettier": "^2.1.2"
   },
   "engines": {
     "node": ">=10"

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const argv = require('yargs').argv
+const yargsParser = require('yargs-parser')
 const colors = require('colors')
 const fs = require('fs')
 const glob = require('glob')
@@ -8,12 +8,17 @@ const jo = require('./main.js')
 const manifest = require('../package.json')
 const promisify = require('util').promisify
 
+const argv = yargsParser(process.argv.slice(2), {
+  boolean: ['version', 'help'],
+  number: ['quality', 'jpegjsMaxResolutionInMP', 'jpegjsMaxMemoryUsageInMB'],
+})
+
 if (argv.version) {
   console.log(manifest.name + ' ' + manifest.version)
   process.exit(0)
 }
 
-if (argv.help || typeof argv._ === 'undefined' || argv._.length === 0) {
+if (argv.help || argv._.length === 0) {
   const help = [
     '',
     'Rotate JPEG images based on EXIF orientation',
@@ -22,9 +27,11 @@ if (argv.help || typeof argv._ === 'undefined' || argv._.length === 0) {
     'jpeg-autorotate <path>',
     '',
     colors.underline('Options'),
-    '--quality=<0-100>   JPEG output quality',
-    '--version           Output current version',
-    '--help              Output help',
+    '--quality=<1-100>                  JPEG output quality',
+    '--jpegjsMaxResolutionInMP=<num>    jpeg-js maxResolutionInMP option',
+    '--jpegjsMaxMemoryUsageInMB=<num>   jpeg-js maxMemoryUsageInMB option',
+    '--version                          Output current version',
+    '--help                             Output help',
     '',
   ]
   console.log(help.join('\n'))
@@ -52,8 +59,13 @@ function processFiles(files, index = 0) {
     return Promise.resolve()
   }
   const filePath = files[index]
+  const options = {
+    quality: argv.quality,
+    jpegjsMaxResolutionInMP: argv.jpegjsMaxResolutionInMP,
+    jpegjsMaxMemoryUsageInMB: argv.jpegjsMaxMemoryUsageInMB,
+  }
   return jo
-    .rotate(filePath, {quality: argv.quality})
+    .rotate(filePath, options)
     .then(({buffer, orientation, quality, dimensions}) => {
       return promisify(fs.writeFile)(files[index], buffer).then(() => {
         return {orientation, quality, dimensions}

--- a/src/transform.js
+++ b/src/transform.js
@@ -6,10 +6,17 @@ const m = {}
  * Decode the given buffer and applies the right transformation
  * Depending on the orientation, it may be a rotation and / or an horizontal flip
  */
-m.rotateBuffer = function (buffer, orientation, quality) {
+m.rotateBuffer = function (buffer, orientation, quality, maxResolutionInMP, maxMemoryUsageInMB) {
   let jpeg = null
   try {
-    jpeg = jpegjs.decode(buffer)
+    const options = {}
+    if (maxResolutionInMP !== null) {
+      options.maxResolutionInMP = maxResolutionInMP
+    }
+    if (maxMemoryUsageInMB !== null) {
+      options.maxMemoryUsageInMB = maxMemoryUsageInMB
+    }
+    jpeg = jpegjs.decode(buffer, options)
   } catch (error) {
     return Promise.reject(error)
   }

--- a/test/errors.spec.js
+++ b/test/errors.spec.js
@@ -21,7 +21,7 @@ describe('errors', function () {
     getTypeof(jo.errors.rotate_file).should.equals('string')
   })
 
-  it('Should return an error if the orientation is 1 (callback)', function (done) {
+  it('Should return a "correct_orientation" error if the orientation is 1 (callback)', function (done) {
     jo.rotate(path.join(__dirname, '/samples/image_1.jpg'), {}, function (error, buffer) {
       error.should.have.property('code').equal(jo.errors.correct_orientation)
       Buffer.isBuffer(buffer).should.be.ok
@@ -29,21 +29,21 @@ describe('errors', function () {
     })
   })
 
-  it('Should return an error if the orientation is 1 (promise)', function (done) {
+  it('Should return a "correct_orientation" error if the orientation is 1 (promise)', function (done) {
     jo.rotate(path.join(__dirname, '/samples/image_1.jpg'), {}).catch((error) => {
       error.should.have.property('code').equal(jo.errors.correct_orientation)
       done()
     })
   })
 
-  it('Should return an error if the orientation is 1 (cli)', function (done) {
+  it('Should return a "correct_orientation" error if the orientation is 1 (cli)', function (done) {
     exec('./src/cli.js ' + path.join(__dirname, '/samples/image_1.jpg'), (error, stdout) => {
       stdout.should.contain('Orientation already correct')
       done()
     })
   })
 
-  it('Should return an error if the image does not exist', function (done) {
+  it('Should return a "read_file" error if the image does not exist', function (done) {
     jo.rotate('foo.jpg', {}, function (error, buffer, orientation) {
       error.should.have.property('code').equal(jo.errors.read_file)
       expect(buffer).to.equal(null)
@@ -52,7 +52,7 @@ describe('errors', function () {
     })
   })
 
-  it('Should return an error if the file is not an image', function (done) {
+  it('Should return a "read_file" error if the file is not an image', function (done) {
     jo.rotate(path.join(__dirname, '/samples/textfile.md'), {}, function (error, buffer, orientation) {
       error.should.have.property('code').equal(jo.errors.read_exif)
       expect(buffer).to.equal(null)
@@ -61,7 +61,7 @@ describe('errors', function () {
     })
   })
 
-  it('Should return an error if the path is not a string/buffer', function (done) {
+  it('Should return a "read_file" error if the path is not a string/buffer', function (done) {
     jo.rotate(['foo'], {}, function (error, buffer, orientation) {
       error.should.have.property('code').equal(jo.errors.read_file)
       expect(buffer).to.equal(null)
@@ -79,7 +79,7 @@ describe('errors', function () {
     })
   })
 
-  it('Should return an error if the image has no orientation tag', function (done) {
+  it('Should return a "no_orientation" error if the image has no orientation tag', function (done) {
     jo.rotate(path.join(__dirname, '/samples/image_no_orientation.jpg'), {}, function (error, buffer, orientation) {
       error.should.have.property('code').equal(jo.errors.no_orientation)
       Buffer.isBuffer(buffer).should.be.ok
@@ -88,7 +88,7 @@ describe('errors', function () {
     })
   })
 
-  it('Should return an error if the image has an unknown orientation tag', function (done) {
+  it('Should return an "unknown_orientation" error if the image has an unknown orientation tag', function (done) {
     jo.rotate(path.join(__dirname, '/samples/image_unknown_orientation.jpg'), {}, function (
       error,
       buffer,
@@ -97,6 +97,46 @@ describe('errors', function () {
       error.should.have.property('code').equal(jo.errors.unknown_orientation)
       Buffer.isBuffer(buffer).should.be.ok
       expect(orientation).to.equal(null)
+      done()
+    })
+  })
+
+  it('Should return a "rotate_file" error if the memory is exceeded when decoding the source image (callback)', function (done) {
+    const options = {
+      jpegjsMaxMemoryUsageInMB: 0.001,
+    }
+    jo.rotate(path.join(__dirname, '/samples/image_2.jpg'), options, function (error, buffer, orientation) {
+      error.should.have.property('code').equal(jo.errors.rotate_file)
+      Buffer.isBuffer(buffer).should.be.ok
+      expect(orientation).to.equal(null)
+      done()
+    })
+  })
+
+  it('Should return a "rotate_file" error if the memory is exceeded when decoding the source image (cli)', function (done) {
+    const cliOption = ' --jpegjsMaxMemoryUsageInMB=0.001'
+    exec('./src/cli.js ' + path.join(__dirname, '/samples/image_2.jpg') + cliOption, (error, stdout) => {
+      stdout.should.contain('Could not rotate image')
+      done()
+    })
+  })
+
+  it('Should return a "rotate_file" error if the image is too big (callback)', function (done) {
+    const options = {
+      jpegjsMaxResolutionInMP: 0.001,
+    }
+    jo.rotate(path.join(__dirname, '/samples/image_2.jpg'), options, function (error, buffer, orientation) {
+      error.should.have.property('code').equal(jo.errors.rotate_file)
+      Buffer.isBuffer(buffer).should.be.ok
+      expect(orientation).to.equal(null)
+      done()
+    })
+  })
+
+  it('Should return a "rotate_file" error if the image is too big (cli)', function (done) {
+    const cliOption = ' --jpegjsMaxResolutionInMP=0.001'
+    exec('./src/cli.js ' + path.join(__dirname, '/samples/image_2.jpg') + cliOption, (error, stdout) => {
+      stdout.should.contain('Could not rotate image')
       done()
     })
   })


### PR DESCRIPTION
Allow to pass options to the `jpegjs.decode()` function.

```shell
jpeg-autorotate --jpegjsMaxResolutionInMP=200 --jpegjsMaxMemoryUsageInMB=1024 /some/image.jpg
```

```js
jo.rotate('/some/image.jpg', {
  jpegjsMaxResolutionInMP: 200,
  jpegjsMaxMemoryUsageInMB: 1024,
})