### PR TITLE
Add @types/jpeg-autorotate to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "cli"
   ],
   "dependencies": {
+    "@types/jpeg-autorotate": "^5.0.0",
     "colors": "^1.4.0",
     "glob": "^7.1.6",
     "jpeg-js": "^0.4.2",


### PR DESCRIPTION
This will automatically install TypeScript type definitions when installing this package.