### PR TITLE
Update deps & support Node 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - '16'
   - '14'
   - '12'
-  - '10'
 script:
   - npm run checkstyle
   - npm run test-ci

--- a/package.json
+++ b/package.json
@@ -36,22 +36,22 @@
   ],
   "dependencies": {
     "colors": "^1.4.0",
-    "glob": "^7.1.6",
-    "jpeg-js": "^0.4.2",
+    "glob": "^7.2.0",
+    "jpeg-js": "^0.4.3",
     "piexifjs": "^1.0.6",
-    "yargs-parser": "^20.2.1"
+    "yargs-parser": "^20.2.9"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "codecov": "^3.8.0",
-    "eslint": "^7.9.0",
-    "eslint-plugin-prettier": "^3.1.4",
-    "mocha": "^8.1.3",
+    "chai": "^4.3.4",
+    "codecov": "^3.8.3",
+    "eslint": "^8.2.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "mocha": "^9.1.3",
     "nyc": "^15.1.0",
-    "prettier": "^2.1.2"
+    "prettier": "^2.4.1"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "preferGlobal": true,
   "license": "MIT"


### PR DESCRIPTION
- Update npm deps
- Test project with node 16
- Drop support for node 10 (end of life was `2021-04-30`)